### PR TITLE
feat(default): add openclaw

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - ./zigbee2mqtt/ks.yaml
   - ./aiostreams/ks.yaml
   - ./aiometadata/ks.yaml
+  - ./openclaw/ks.yaml

--- a/kubernetes/apps/default/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/default/openclaw/app/helmrelease.yaml
@@ -1,0 +1,177 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openclaw
+spec:
+  interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: openclaw
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      openclaw:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        initContainers:
+          # Seeds openclaw.json / AGENTS.md into the state volume on first run only.
+          # The gateway rewrites its own config at runtime (Control UI, `config set`),
+          # so re-copying on every restart would clobber whatever was set in the UI.
+          seed-config:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                mkdir -p /home/node/.openclaw/workspace
+                [ -f /home/node/.openclaw/openclaw.json ] \
+                  || cp /seed/openclaw.json /home/node/.openclaw/openclaw.json
+                [ -f /home/node/.openclaw/workspace/AGENTS.md ] \
+                  || cp /seed/AGENTS.md /home/node/.openclaw/workspace/AGENTS.md
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+        containers:
+          app:
+            image:
+              repository: ghcr.io/openclaw/openclaw
+              tag: 2026.7.1@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
+            command: ["node", "/app/dist/index.js", "gateway", "run"]
+            env:
+              HOME: /home/node
+              NODE_ENV: production
+              TZ: America/New_York
+              OPENCLAW_HOME: /home/node
+              OPENCLAW_STATE_DIR: /home/node/.openclaw
+              OPENCLAW_CONFIG_DIR: /home/node/.openclaw
+              OPENCLAW_CONFIG_PATH: /home/node/.openclaw/openclaw.json
+              OPENCLAW_WORKSPACE_DIR: /home/node/.openclaw/workspace
+              OPENCLAW_DISABLE_BONJOUR: "1"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 18789
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: openclaw
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames: ["openclaw.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    configMaps:
+      config:
+        data:
+          openclaw.json: |
+            {
+              "gateway": {
+                "mode": "local",
+                "bind": "lan",
+                "port": 18789,
+                "auth": { "mode": "token" },
+                "controlUi": {
+                  "enabled": true,
+                  "allowedOrigins": ["https://openclaw.${SECRET_DOMAIN}"]
+                }
+              },
+              "agents": {
+                "defaults": { "workspace": "~/.openclaw/workspace" },
+                "list": [
+                  {
+                    "id": "default",
+                    "name": "OpenClaw Assistant",
+                    "workspace": "~/.openclaw/workspace"
+                  }
+                ]
+              },
+              "cron": { "enabled": false }
+            }
+          AGENTS.md: |
+            # OpenClaw Assistant
+
+            You are a helpful AI assistant running in a single-node Talos homelab
+            cluster. Edit this file in the workspace to change your own instructions.
+    persistence:
+      data:
+        existingClaim: openclaw-data
+        advancedMounts:
+          openclaw:
+            seed-config:
+              - path: /home/node/.openclaw
+            app:
+              - path: /home/node/.openclaw
+      seed:
+        type: configMap
+        identifier: config
+        advancedMounts:
+          openclaw:
+            seed-config:
+              - path: /seed
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          openclaw:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/default/openclaw/app/kustomization.yaml
+++ b/kubernetes/apps/default/openclaw/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/default/openclaw/app/ocirepository.yaml
+++ b/kubernetes/apps/default/openclaw/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openclaw
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/openclaw/app/pvc.yaml
+++ b/kubernetes/apps/default/openclaw/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: topolvm-thin-provisioner

--- a/kubernetes/apps/default/openclaw/ks.yaml
+++ b/kubernetes/apps/default/openclaw/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openclaw
+  namespace: default
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: topolvm
+      namespace: topolvm-system
+  path: ./kubernetes/apps/default/openclaw/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app


### PR DESCRIPTION
Deploys [OpenClaw](https://github.com/openclaw/openclaw) (personal AI assistant gateway) into the `default` namespace on the bjw-s `app-template` chart, following the same layout as `aiometadata`.

## Notable decisions

**`gateway.bind: lan`.** Upstream's own Kubernetes manifests bind the gateway to loopback inside the pod, which only works with `kubectl port-forward` — a `Service` cannot reach it. Their docs call this out and say to change the bind for Ingress/LB access, so the seeded config uses `lan` (`0.0.0.0`). Non-loopback binds require gateway auth, which stays enabled in token mode.

**Config is seeded once, not on every restart.** Upstream's init container unconditionally `cp`s `openclaw.json` into the state dir. The gateway rewrites that file at runtime (Control UI, `config set`), so this version only copies when the file is absent. Changing the seed in git will therefore not affect an already-initialised volume — that is deliberate.

**Routed via `envoy-internal`.** The gateway drives an agent with tool access and its only protection is a bearer token, so it is LAN-only rather than public through cloudflared.

**No ExternalSecret.** `OPENCLAW_GATEWAY_TOKEN` is auto-generated on first start and persisted to the PVC; provider API keys are set in the Control UI. Nothing needs to exist in 1Password for this to come up.

## Retrieving the gateway token after first start

```sh
kubectl -n default exec deploy/openclaw -- \
  sh -c 'grep -o "\"token\"[^,]*" /home/node/.openclaw/openclaw.json'
```

## Validation

| check | result |
|---|---|
| `kustomize build --load-restrictor=LoadRestrictionsNone` | pass |
| `kubeconform.sh kubernetes` | pass |
| `helm template` against app-template 4.6.2 | pass |
| `flux-local test --enable-helm --all-namespaces` | 50 passed |

Rendering caught one real bug pre-push: the chart names the generated ConfigMap `openclaw`, not `openclaw-config`, so the persistence entry now references it by `identifier` instead of a literal name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)